### PR TITLE
Change code sample to use non-local interface binding by default

### DIFF
--- a/docs/03.markdown
+++ b/docs/03.markdown
@@ -36,11 +36,11 @@ object AsyncPlan extends unfiltered.filter.async.Plan  {
     }   
 }
 //then you can register this plan with jetty as usual
-unfiltered.jetty.Server.local(8080).plan(AsyncPlan).run()
+unfiltered.jetty.Server.http(8080).plan(AsyncPlan).run()
 ```
 
-> **Note:** `local(8080)` binds to the loopback network
-    interface. Alternately, `http(8080)` binds to all interfaces.
+> **Note:** Alternately, `local(8080)` binds to the loopback network
+    interface only. 
 
 #### Netty Channel Handlers (unfiltered-netty)
 
@@ -94,5 +94,5 @@ import unfiltered.response._
 val hello = unfiltered.netty.cycle.Planify {
   case _ => ResponseString("hello world")
 }
-unfiltered.netty.Server.local(8080).plan(hello).run()
+unfiltered.netty.Server.http(8080).plan(hello).run()
 ```


### PR DESCRIPTION
Closes what's proven to be a recurring trap here at REA Group. A few months back, I lost 2 days to diagnosing use of `local` instead of `http`, because other issues like AWS health checks obscured the real issue. 

So I added the note. But despite this another team got tripped up by the exact same problem just today. Human nature is to cut and paste the provided code sample, so we should make it work by default.
